### PR TITLE
Shape file of buurt 2009: path not found

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -6,10 +6,9 @@ shapefiles <- c(
   "2013"="http://download.cbs.nl/regionale-kaarten/shape-2013-versie-3-0.zip",
   "2014"="https://www.cbs.nl/-/media/_pdf/2016/35/shape%202014%20versie%2030.zip",
   "2015"="https://www.cbs.nl/-/media/_pdf/2017/36/buurt_2015.zip",
-  "2016"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202016%20versie%2030.zip",
-  "2017"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202017%20versie%2020.zip",
-  "2018"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202018%20versie%2010.zip"
-
+  "2016"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/shape%202016%20versie%2030.zip", 
+  "2017"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2017_v3.zip",
+  "2018"="https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2018_v2.zip"
 )
 
 #' List available CBS wijk en buurtkaarten

--- a/R/read.R
+++ b/R/read.R
@@ -28,8 +28,15 @@ cbs_shape_read <- function(year, level="gem", path=NULL, wgs84=FALSE, verbose=TR
 
   # shapefile path
   shp_path <- Sys.glob(file.path(path, sprintf("*%s*%s*.shp", level, year)))
+
+  # if missing path try to find it using fuzzy matching  
   if (length(shp_path) == 0){
-    stop(paste("data not found on location:", path))
+    all_files <- grep(year, list.files(path, pattern = '.shp$'), value = T)
+    good_file <- agrep(level, all_files, max.distance = 2, value = T)
+    shp_path <- paste(path, good_file, sep = '/')
+    if (length(shp_path) == 0){
+        stop(paste("data not found on location:", path))
+    }      
   }
 
   # load shape

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Get a list of all available shapefiles:
                                                                                                                          2015 
                                                                      "https://www.cbs.nl/-/media/_pdf/2017/36/buurt_2015.zip" 
                                                                                                                          2016 
-"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202016%20versie%2030.zip" 
+"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/shape%202016%20versie%2030.zip"
                                                                                                                          2017 
-"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202017%20versie%2020.zip" 
+"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2017_v3.zip"
                                                                                                                          2018 
-"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/2018/shape%202018%20versie%2010.zip" 
+"https://www.cbs.nl/-/media/cbs/dossiers/nederland%20regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2018_v2.zip"
 
 ```
 


### PR DESCRIPTION
The filename of the buurt shape files in year 2009  contains the string 'brt' instead of 'buurt' causing shp_path in the function cbs_read_shape to be length 0 .

Proposed solution is to search for the correct file name using approximate string matching.